### PR TITLE
Fix hotspot being unreachable in Chrome and preview never loading

### DIFF
--- a/os/network/dnsmasq-shared.properties
+++ b/os/network/dnsmasq-shared.properties
@@ -1,4 +1,7 @@
-addn-hosts=/etc/hosts
+# .local belongs to mDNS, never forward it upstream
+local=/local/
+# answer our own name with this interface's address, not the 127.0.1.1 from /etc/hosts
+interface-name=planktoscope.local,wlan0
 domain-needed # never forward plain names (without a dot or domain part)
 bogus-priv # never forward addresses in the non-routed address spaces
 # don't advertise ourselves as a default route to the internet

--- a/os/network/dnsmasq-shared.properties
+++ b/os/network/dnsmasq-shared.properties
@@ -4,7 +4,6 @@ local=/local/
 interface-name=planktoscope.local,wlan0
 domain-needed # never forward plain names (without a dot or domain part)
 bogus-priv # never forward addresses in the non-routed address spaces
-# don't advertise ourselves as a default route to the internet
-dhcp-option=wlan0,option:router
-# Advertise ourselves as a route for addresses on 192.168.4.*, even if we're not a default route.
-dhcp-option=wlan0,option:classless-static-route,192.168.4.0/24,0.0.0.0
+# an interface with no gateway reads as "no connectivity" to the OS, which blocks
+# navigation in Chrome and stops WebRTC gathering candidates on it
+dhcp-option=wlan0,option:router,192.168.4.1


### PR DESCRIPTION
Over the Wi-Fi hotspot the UI was unreachable in Chrome and the camera preview never loaded in any browser that I tried. Both worked over LAN.

**Root cause:** the hotspot suppressed the DHCP router option, leaving clients with no default route. macOS reads that as no connectivity, so Chrome refuses to open sockets at all and browsers won't gather WebRTC candidates on the interface. One config line explains both symptoms.

The decisive test was loading the raw IP `http://192.168.4.1` in the failing browser — no DNS in the path, still `ERR_INTERNET_DISCONNECTED` — which ruled out every naming theory i could think of in one step.

A second commit fixes an unrelated defect found on the way: dnsmasq was serving `/etc/hosts` to clients, telling them the scope was at their own `127.0.1.1`.

**Trade-off to review:** clients now route through the instrument by default. `ipv4.method=shared` already permitted forwarding to any destination including the wired LAN — this makes it the automatic path rather than something requiring a manual route. If that isn't wanted, the forward chain should be narrowed to block wlan0 → LAN.

**Verified** on planktoscope-great-door in Chrome and Firefox: UI loads, preview renders, WHEP session 5s failures → 64s normal session.