### PR TITLE
mediamtx: reachable ICE candidates, no redundant config rewrites, imager follows restarts

### DIFF
--- a/controller/imager/planktoscope-org.controller.imager.service
+++ b/controller/imager/planktoscope-org.controller.imager.service
@@ -3,6 +3,7 @@ Wants=mosquitto.service
 After=mosquitto.service
 After=nodered.service
 After=mediamtx.service
+PartOf=mediamtx.service
 
 [Service]
 Type=simple

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -1,7 +1,6 @@
 import { readFile, writeFile } from "fs/promises"
 import ini from "ini"
 import { fileURLToPath } from "url"
-import { configureMediaMTX } from "./mediamtx.js"
 import { configureCockpit } from "./cockpit.js"
 import { $ } from "./exec.js"
 import os from "node:os"
@@ -26,7 +25,6 @@ export async function updateName(name) {
   const hostname = `planktoscope-${name}`
   await $`hostnamectl hostname ${hostname}`
   await updateHosts(hostname)
-  await updateMediamtx(hostname)
   await updateCockpit(hostname)
 }
 
@@ -39,10 +37,6 @@ async function updateWifiSSID(name) {
   conn.wifi.ssid = `PlanktoScope ${name}`
 
   await writeFile(path, ini.stringify(conn))
-}
-
-async function updateMediamtx(hostname) {
-  await configureMediaMTX({ hostname })
 }
 
 async function updateCockpit(hostname) {

--- a/lib/mediamtx.js
+++ b/lib/mediamtx.js
@@ -6,16 +6,15 @@ import { getWiredAddress } from "./helpers.js"
 
 const config_path = "/etc/mediamtx.yaml"
 
-export async function configureMediaMTX({ hostname, address } = {}) {
-  const config = yaml.load(await readFile(config_path, "utf8"))
+export async function configureMediaMTX({ address } = {}) {
+  const current = await readFile(config_path, "utf8")
+  const config = yaml.load(current)
   if (address) {
     config.webrtcAdditionalHosts[0] = address
   }
-  if (hostname) {
-    config.webrtcAdditionalHosts[1] = hostname
-    config.webrtcAdditionalHosts[2] = `${hostname}.local`
-  }
-  await writeFile(config_path, yaml.dump(config))
+  const rendered = yaml.dump(config)
+  if (rendered === current) return
+  await writeFile(config_path, rendered)
 }
 
 export const reconfigureMediaMTX = queue(

--- a/os/mediamtx/mediamtx.yaml
+++ b/os/mediamtx/mediamtx.yaml
@@ -2,31 +2,14 @@
 
 # https://mediamtx.org/docs/usage/webrtc-specific-features#solving-webrtc-connectivity-issues
 webrtcAdditionalHosts: [
-    # current ip address
+    # current ip address, substituted at startup by lib/mediamtx.js
     192.0.2.1,
-    # hostname
-    raspberrypi,
-    # hostname.local
-    raspberrypi.local,
-    # Place new values below in any order
-    # see lib/mediamtx.js
-    localhost,
-    planktoscope.local,
+    # hotspot address, always reachable by a client on the AP
     192.168.4.1,
   ]
 
 # https://mediamtx.org/docs/usage/decrease-packet-loss
 writeQueueSize: 1024
-
-# ICE servers. Needed only when local listeners can't be reached by clients.
-# STUN servers allows to obtain and share the public IP of the server.
-# TURN/TURNS servers forces all traffic through them.
-webrtcICEServers2:
-  - url: stun:stun.cloudflare.com:3478 # Cloudfare
-  - url: stun:stun.fbsbx.com:3478 # Facebook / Meta
-  # Google stun server is meh
-  # https://www.youtube.com/watch?v=sO3-GbDWZG4
-  # - url: stun.l.google.com:19302
 
 paths:
   # This is published by controller at rtsp://127.0.0.1:8554/cam


### PR DESCRIPTION
Three defects found while I was investigating the hotspot preview failure. None of them was the cause somehow; they are robustness issues probably worth fixing on their own merits, kept separate from the hotspot PR so they can be judged that way.

Each is independently verified on hardware:

- candidate list reduced to real interface addresses
- five consecutive config-writer runs leave mtime unchanged, publisher steady at 543 KB/s
- restarting mediamtx changes the imager MainPID

The PartOf change is a partial fix — it covers systemctl restart but not mediamtx's internal config hot-reload. See its commit message.