### PR TITLE
Make the camera preview play on iOS (iPhone/iPad)

### DIFF
--- a/frontend/src/pages/preview/Stream.jsx
+++ b/frontend/src/pages/preview/Stream.jsx
@@ -22,14 +22,20 @@ export default function Stream() {
       class={styles.video}
       muted
       autoplay
+      playsinline
       disablepictureinpicture
       preload="auto"
     />
   )
 
+  function playVideo() {
+    video.play().catch((err) => console.error("video play rejected", err))
+  }
+
   function onVideoLoad() {
     stream_container.style.display = "flex"
     loader_container.style.display = "none"
+    playVideo()
     new Zoomist(zoomist_container, {
       slider: true,
       zoomer: true,
@@ -49,6 +55,7 @@ export default function Stream() {
     onTrack: (evt) => {
       console.debug("mediamtx track", evt)
       video.srcObject = evt.streams[0]
+      playVideo()
     },
     onDataChannel: (evt) => {
       evt.channel.binaryType = "arraybuffer"


### PR DESCRIPTION
The camera preview could not render on iPhone or iPad. Stream.jsx created its <video> without playsinline, which iOS requires for inline playback — without it iOS forces fullscreen or refuses to start, independently of any network condition.

Adds playsinline, plus two explicit play() attempts covering the two ways iOS declines to autostart: from a srcObject assignment, and for an element that was hidden when the stream arrived (stream_container is display: none until loadedmetadata).