### PR TITLE
fix(preview): make the camera stream play in Safari

### DIFF
--- a/frontend/src/pages/preview/Stream.jsx
+++ b/frontend/src/pages/preview/Stream.jsx
@@ -16,20 +16,43 @@ export default function Stream() {
   let loader_container
   let stream_container
 
+  const rotation = new URL(document.location).searchParams.get("rotate")
+
   const video = (
     <video
       on:loadedmetadata={onVideoLoad}
       class={styles.video}
+      style={
+        rotation
+          ? { "max-width": "calc(100vh + 4px)", "max-height": "calc(100vw + 4px)" }
+          : undefined
+      }
       muted
       autoplay
+      playsinline
       disablepictureinpicture
       preload="auto"
     />
   )
 
+  function playVideo() {
+    video.muted = true
+    video.play().catch((err) => console.error("video play rejected", err))
+  }
+
   function onVideoLoad() {
     stream_container.style.display = "flex"
     loader_container.style.display = "none"
+    if (rotation) {
+      const style = stream_container.style
+      style.position = "absolute"
+      style.top = "50%"
+      style.left = "50%"
+      style.width = "calc(100vh + 4px)"
+      style.height = "calc(100vw + 4px)"
+      style.transform = `translate(-50%, -50%) rotate(${rotation}deg)`
+    }
+    playVideo()
     new Zoomist(zoomist_container, {
       slider: true,
       zoomer: true,
@@ -41,6 +64,7 @@ export default function Stream() {
   const url = new URL(document.location)
   url.port = 8889
   url.pathname = "/cam/whep"
+  url.search = ""
   const reader = new MediaMTXWebRTCReader({
     url,
     onError: (err) => {


### PR DESCRIPTION
**Root cause:** WebKit will not play video inside a CSS-transformed iframe. The dashboard rotates the preview iframe 90° to show the landscape sensor as a portrait field. The stream connected and buffered normally — `readyState=4`, muted, paused, `NotAllowedError` — and clicking play did nothing either, which is the tell that the feature is denied for the browsing context rather than merely throttled.

Isolated by loading the same preview several ways in Safari:

| | Safari |
|---|---|
| standalone page | plays |
| plain iframe | plays |
| iframe + `allow="autoplay"` | plays |
| iframe with `transform: rotate(-90deg)` | **blank** |

**Fix:** move the rotation inside the frame. The preview accepts an optional `?rotate` and transforms its own container once it is visible; the dashboard drops its transform and passes `?rotate=-90`. Because `.video` is capped at `100vw`/`100vh`, those swap with the rotation or the frame is left inset.

Also fixes the WHEP URL inheriting the page's query string — signalling was posting to `/cam/whep?rotate=-90`.

`playsinline` and `muted` set as a property are WebKit hardening, flagged as such rather than claimed as fixes.

All in `Stream.jsx`, not the vendored `reader.js`, so a mediamtx version bump won't wipe it.

**Depends on the matching dashboard change** (drop the iframe transform, pass `?rotate=-90`)
### Node-RED changes necessary for correct rotation

**Two edits per node:** drop the transform from the CSS, and add `?rotate=-90` to the iframe `src`.

#### Nodes changed

| Node ID | Where | Selector carrying the transform |
| --- | --- | --- |
| `5fedc522b345193c` | Preview → Streaming | `.responsive-iframe` |
| `6a0b3b7b9f767135` | Acquisition → Streaming | `.responsive-iframe` |
| `db1ef284071e60a1` | Preview → Camera Calibration modal | `.rotated-content` |
| `df1a2b3c4d5e6f70` | Preview → Dark Field panel | `.rotated-content` |

---

#### Pattern A — The iframe itself is transformed
*Applies to: `5fedc522b345193c`, `6a0b3b7b9f767135`*

```diff
   .responsive-iframe {
     position: absolute;
-    top: 50%;
-    left: 50%;
-    /* Légère augmentation pour supprimer les micro-bordures noires */
-    width: calc(133.33% + 4px);
-    height: calc(75% + 4px);
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     border: none;
     pointer-events: auto;
-    transform: translate(-50%, -50%) rotate(-90deg);
     z-index: 1;
   }

Verified on planktoscope-great-door against the stock mediamtx config in Chrome, Firefox and Safari.